### PR TITLE
feat: surface published projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
 				"@sveltejs/adapter-auto": "^7.0.0",
 				"@sveltejs/kit": "^2.49.1",
 				"@sveltejs/vite-plugin-svelte": "^6.2.1",
+				"@types/node": "^22.10.1",
 				"prettier": "^3.7.4",
 				"prettier-plugin-svelte": "^3.4.0",
 				"svelte": "^5.45.6",
 				"svelte-check": "^4.3.4",
+				"tsx": "^4.19.1",
 				"typescript": "^5.9.3",
 				"vite": "^7.2.6"
 			}
@@ -991,6 +993,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/node": {
+			"version": "22.19.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+			"integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1167,6 +1179,19 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
 		"node_modules/is-reference": {
@@ -1346,6 +1371,16 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/rollup": {
 			"version": "4.55.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
@@ -1514,6 +1549,26 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.27.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1527,6 +1582,13 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/vite": {
 			"version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -5,23 +5,26 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build",
+		"build": "npm run validate:content && vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
-		"lint": "prettier --check ."
+		"lint": "prettier --check .",
+		"validate:content": "tsx scripts/validate-projects.ts"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.49.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
+		"@types/node": "^22.10.1",
 		"prettier": "^3.7.4",
 		"prettier-plugin-svelte": "^3.4.0",
 		"svelte": "^5.45.6",
 		"svelte-check": "^4.3.4",
 		"typescript": "^5.9.3",
-		"vite": "^7.2.6"
+		"vite": "^7.2.6",
+		"tsx": "^4.19.1"
 	}
 }

--- a/scripts/validate-projects.ts
+++ b/scripts/validate-projects.ts
@@ -1,0 +1,19 @@
+import { loadProjectDataset } from '../src/lib/server/projects';
+
+async function main(): Promise<void> {
+	const dataset = await loadProjectDataset(true);
+	const published = dataset.published.length;
+	const archived = dataset.archived.length;
+	const drafts = dataset.drafts.length;
+	const redirects = Object.keys(dataset.redirects).length;
+
+	console.log(
+		`Validated ${dataset.projects.length} project(s): ${published} published, ${archived} archived, ${drafts} draft, ${redirects} redirect(s).`
+	);
+}
+
+main().catch((error) => {
+	console.error('Project content validation failed:');
+	console.error(error instanceof Error ? (error.stack ?? error.message) : error);
+	process.exit(1);
+});

--- a/src/lib/server/projects.ts
+++ b/src/lib/server/projects.ts
@@ -1,0 +1,324 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export type ProjectStatus = 'draft' | 'published' | 'archived';
+
+export interface ImageObject {
+	url: string;
+	alt?: string;
+	caption?: string;
+}
+
+export interface Collaborator {
+	name: string;
+	role?: string;
+	url?: string;
+}
+
+export interface Timeframe {
+	start?: string;
+	end?: string;
+	label?: string;
+}
+
+export interface ProjectPublic {
+	slug: string;
+	title: string;
+	summary: string;
+	intro?: string;
+	body?: string;
+	heroImage?: ImageObject;
+	gallery?: ImageObject[];
+	tags?: string[];
+	category?: string;
+	tech?: string[];
+	featured?: boolean;
+	weight?: number;
+	sortDate?: string;
+	timeframe?: Timeframe;
+	role?: string;
+	collaborators?: Collaborator[];
+	clientPublicName?: string;
+	liveUrl?: string;
+	repoUrl?: string;
+	canonical?: string;
+	seo?: Record<string, unknown>;
+}
+
+export interface ProjectInternal {
+	id: string;
+	status: ProjectStatus;
+	createdAt: string;
+	updatedAt: string;
+	contentUri: string;
+	aliases: string[];
+	internalNotes?: string;
+	metadata?: Record<string, unknown>;
+}
+
+export interface ProjectBundle {
+	slug: string;
+	status: ProjectStatus;
+	public: ProjectPublic;
+	internal: ProjectInternal;
+}
+
+export interface ProjectDataset {
+	projects: ProjectBundle[];
+	published: ProjectPublic[];
+	archived: ProjectPublic[];
+	drafts: ProjectBundle[];
+	redirects: Record<string, string>;
+}
+
+interface RawProjectRecord {
+	[key: string]: unknown;
+}
+
+const REQUIRED_FIELDS = [
+	'id',
+	'slug',
+	'title',
+	'summary',
+	'status',
+	'createdAt',
+	'updatedAt',
+	'contentUri'
+] as const;
+
+const PUBLIC_FIELDS = [
+	'slug',
+	'title',
+	'summary',
+	'intro',
+	'body',
+	'heroImage',
+	'gallery',
+	'tags',
+	'category',
+	'tech',
+	'featured',
+	'weight',
+	'sortDate',
+	'timeframe',
+	'role',
+	'collaborators',
+	'clientPublicName',
+	'liveUrl',
+	'repoUrl',
+	'canonical',
+	'seo'
+] as const;
+
+const INTERNAL_FIELDS = [
+	'id',
+	'status',
+	'createdAt',
+	'updatedAt',
+	'contentUri',
+	'aliases',
+	'internalNotes',
+	'metadata'
+] as const;
+
+const ALLOWED_FIELDS = new Set<string>([...PUBLIC_FIELDS, ...INTERNAL_FIELDS]);
+
+const PROJECTS_DIR = path.resolve(process.cwd(), 'content', 'projects');
+
+let cachedDataset: ProjectDataset | null = null;
+
+export async function loadProjectDataset(forceReload = false): Promise<ProjectDataset> {
+	if (cachedDataset && !forceReload) {
+		return cachedDataset;
+	}
+
+	const entries = await fs.readdir(PROJECTS_DIR, { withFileTypes: true });
+	const aliasMap = new Map<string, string>();
+	const seenSlugs = new Set<string>();
+	const bundles: ProjectBundle[] = [];
+
+	for (const entry of entries) {
+		if (!entry.isDirectory()) {
+			continue;
+		}
+
+		const slugFolder = entry.name;
+		const projectDir = path.join(PROJECTS_DIR, slugFolder);
+		const jsonPath = path.join(projectDir, 'project.json');
+		const markdownPath = path.join(projectDir, 'content.md');
+
+		const [jsonContent, markdownContent] = await Promise.all([
+			fs.readFile(jsonPath, 'utf-8'),
+			fs.readFile(markdownPath, 'utf-8')
+		]);
+
+		const raw = JSON.parse(jsonContent) as RawProjectRecord;
+		validateRecord(raw, slugFolder);
+
+		const slug = raw.slug as string;
+
+		if (seenSlugs.has(slug)) {
+			throw new Error(`Duplicate project slug detected: ${slug}`);
+		}
+		seenSlugs.add(slug);
+
+		const status = raw.status as ProjectStatus;
+		const aliases = normaliseAliases(raw.aliases);
+
+		for (const alias of aliases) {
+			if (alias === slug) {
+				throw new Error(`Alias \"${alias}\" duplicates canonical slug for ${slug}`);
+			}
+
+			const existing = aliasMap.get(alias);
+			if (existing && existing !== slug) {
+				throw new Error(`Alias \"${alias}\" already assigned to ${existing}`);
+			}
+
+			aliasMap.set(alias, slug);
+		}
+
+		const publicData = derivePublicData(raw, markdownContent);
+		const internalData: ProjectInternal = {
+			id: raw.id as string,
+			status,
+			createdAt: raw.createdAt as string,
+			updatedAt: raw.updatedAt as string,
+			contentUri: raw.contentUri as string,
+			aliases,
+			internalNotes: raw.internalNotes as string | undefined,
+			metadata: (raw.metadata as Record<string, unknown>) ?? undefined
+		};
+
+		bundles.push({
+			slug,
+			status,
+			public: publicData,
+			internal: internalData
+		});
+	}
+
+	const published = bundles
+		.filter((bundle) => bundle.status === 'published')
+		.map((bundle) => bundle.public);
+
+	const archived = bundles
+		.filter((bundle) => bundle.status === 'archived')
+		.map((bundle) => bundle.public);
+
+	const drafts = bundles.filter((bundle) => bundle.status === 'draft');
+
+	cachedDataset = {
+		projects: bundles,
+		published,
+		archived,
+		drafts,
+		redirects: Object.fromEntries(aliasMap.entries())
+	};
+
+	return cachedDataset;
+}
+
+export async function loadPublishedProjects(forceReload = false): Promise<ProjectPublic[]> {
+	const dataset = await loadProjectDataset(forceReload);
+	return dataset.published.slice();
+}
+
+export function invalidateProjectDatasetCache(): void {
+	cachedDataset = null;
+}
+
+function validateRecord(raw: RawProjectRecord, folderName: string): void {
+	const keys = Object.keys(raw);
+	for (const key of keys) {
+		if (!ALLOWED_FIELDS.has(key)) {
+			throw new Error(`Unexpected field \"${key}\" in project record ${folderName}`);
+		}
+	}
+
+	for (const field of REQUIRED_FIELDS) {
+		if (raw[field] === undefined || raw[field] === null) {
+			throw new Error(`Missing required field \"${field}\" in project record ${folderName}`);
+		}
+	}
+
+	if (typeof raw.id !== 'string' || !raw.id.trim()) {
+		throw new Error(`Project ${folderName} must provide a non-empty string id`);
+	}
+
+	if (typeof raw.slug !== 'string' || !raw.slug.trim()) {
+		throw new Error(`Project ${folderName} must provide a non-empty string slug`);
+	}
+
+	if (raw.slug !== folderName) {
+		throw new Error(`Slug mismatch: record slug ${raw.slug} does not match folder ${folderName}`);
+	}
+
+	const allowedStatuses: ProjectStatus[] = ['draft', 'published', 'archived'];
+	if (!allowedStatuses.includes(raw.status as ProjectStatus)) {
+		throw new Error(`Invalid status \"${raw.status}\" in project ${folderName}`);
+	}
+
+	if (typeof raw.contentUri !== 'string' || !raw.contentUri.trim()) {
+		throw new Error(`Project ${folderName} must specify a contentUri string`);
+	}
+
+	for (const dateField of ['createdAt', 'updatedAt']) {
+		if (typeof raw[dateField] !== 'string' || !(raw[dateField] as string).trim()) {
+			throw new Error(`Project ${folderName} must provide a string ${dateField}`);
+		}
+	}
+
+	const expectedContentUri = path.posix.join('content', 'projects', folderName, 'content.md');
+	if (raw.contentUri !== expectedContentUri) {
+		throw new Error(
+			`contentUri mismatch in ${folderName}: expected ${expectedContentUri}, received ${raw.contentUri}`
+		);
+	}
+}
+
+function normaliseAliases(value: unknown): string[] {
+	if (!value) {
+		return [];
+	}
+
+	if (!Array.isArray(value)) {
+		throw new Error('aliases must be an array of strings');
+	}
+
+	const aliases = value.map((item) => {
+		if (typeof item !== 'string' || !item.trim()) {
+			throw new Error('aliases must contain non-empty strings');
+		}
+
+		return item.trim();
+	});
+
+	return [...new Set(aliases)];
+}
+
+function derivePublicData(raw: RawProjectRecord, markdown: string): ProjectPublic {
+	const result: Partial<ProjectPublic> = {};
+
+	for (const field of PUBLIC_FIELDS) {
+		if (raw[field] !== undefined) {
+			(result as Record<string, unknown>)[field] = raw[field];
+		}
+	}
+
+	if (!result.body && markdown.trim().length > 0) {
+		result.body = markdown;
+	}
+
+	if (typeof result.heroImage === 'string') {
+		result.heroImage = { url: result.heroImage };
+	}
+
+	if (Array.isArray(result.gallery)) {
+		result.gallery = result.gallery.map((item) =>
+			typeof item === 'string' ? { url: item } : (item as ImageObject)
+		);
+	}
+
+	return result as ProjectPublic;
+}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from './$types';
+import { loadPublishedProjects } from '$lib/server/projects';
+
+export const load: PageServerLoad = async () => {
+	const projects = await loadPublishedProjects();
+
+	return {
+		projects
+	};
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,43 @@
-<h1>Preview Test</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	const { projects } = data;
+</script>
+
+<section>
+	<header>
+		<h1>Selected Work</h1>
+		<p>Recent projects that are ready to share.</p>
+	</header>
+
+	{#if projects.length === 0}
+		<p>Public case studies are coming soon. Check back for new launches.</p>
+	{:else}
+		<ul>
+			{#each projects as project}
+				<li>
+					<article>
+						<h2>{project.title}</h2>
+						<p>{project.summary}</p>
+
+						{#if project.tags && project.tags.length > 0}
+							<ul>
+								{#each project.tags as tag}
+									<li>{tag}</li>
+								{/each}
+							</ul>
+						{/if}
+
+						{#if project.liveUrl}
+							<p>
+								<a href={project.liveUrl} rel="noopener" target="_blank">Visit site</a>
+							</p>
+						{/if}
+					</article>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</section>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler"
+		"moduleResolution": "bundler",
+		"types": ["node"]
 	}
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files


### PR DESCRIPTION
## Summary
- add loadPublishedProjects helper so routes can reuse cached public dataset
- wire the index load function to fetch published projects from the server loader
- render a basic “Selected Work” list with empty state on the landing page

Closes #16.

## Testing
- npm run validate:content
- npm run check
- npm run lint
