### PR TITLE
feat(css): introduce design tokens

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,7 @@
 - Run `npm run format` before committing to keep Prettier happy. If commits are not planned, at least run `npm run lint` and fix any reported issues.
 - Use spaces instead of tabs; the Prettier defaults in this repo expect two-space indentation.
 - Keep documentation updates in sync with sample content under `content/projects/` so references do not drift.
+- Coordinate design-system work against the "Foundation Design System (CSS Variables)" milestone; ensure related PRs link the milestone issues and keep `docs/design-system.md` plus the style-guide route current.
 - Avoid committing large binary assets; prefer lightweight placeholders and place production-ready images under `static/images/projects/{slug}/`.
 - Follow a semantic git flow:
   - Branch off `main` using `issue{number}-short-description`.

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# VsCode
+.vscode/settings.json

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,38 @@
+# Design System Overview
+
+This document tracks the "Foundation Design System (CSS Variables)" milestone. The work is split across issues #18–#23 and focuses on:
+
+- Defining CSS custom property tokens for color, typography, spacing, radii, shadows, borders, focus, and layout.
+- Applying baseline typography, interactive element styles, and layout primitives across the app using vanilla CSS.
+- Meeting WCAG 2.1 AA expectations with explicit focus treatments, reduced-motion support, and high-contrast themes.
+- Documenting usage patterns and examples, including a SvelteKit style-guide route for visual regression checks.
+
+Refer to the linked issues for detailed acceptance criteria. Update this document as the system evolves to keep tokens, conventions, and integration steps current.
+
+## Token architecture (issue #18)
+
+All design tokens live in `src/lib/styles/tokens.css`. The file is organised by semantic group so future contributors can reason about the system without additional tooling:
+
+- Palette definitions prefixed with `--color-light-*` and `--color-dark-*` supply accessible color roles for light and dark themes.
+- Semantic tokens (e.g. `--color-bg`, `--color-text-muted`, `--color-accent-on`) are the only variables components should consume directly.
+- Typography tokens (`--font-family-*`, `--font-size-*`, `--line-height-*`, `--font-weight-*`) assume a 16px root font size and use rem units.
+- The spacing scale provides 4px fine control (`--space-1`) with the core 8px grid continuing through `--space-10`.
+- Border, radius, shadow, focus, motion, z-index, and container tokens centralise recurring layout values and ensure ADA/WCAG requirements remain intact.
+
+### Light / dark theming
+
+- `:root` defaults to the light palette and declares `color-scheme: light dark` so browsers expose both themes when automatic switching is enabled.
+- `@media (prefers-color-scheme: dark)` overrides semantic tokens with the dark palette while respecting user preferences.
+- Manual overrides are available via the `.theme-dark`, `.theme-light`, `:root[data-theme="dark"]`, and `:root[data-theme="light"]` selectors. These overrides are CSS-only and can be toggled by applying the class or attribute to `html` or `body`—no JavaScript is required in the MVP.
+
+### Accessibility considerations
+
+- Color pairs are chosen to meet WCAG 2.1 AA contrast ratios (4.5:1 for text, 3:1 for large text and UI controls). If any token combination fails due to future palette adjustments, document the exception and mitigation tactics here.
+- Focus styles should consume `--color-focus-ring`, `--focus-ring-width`, and `--focus-ring-offset` to ensure consistent, highly visible outlines across components.
+- Motion tokens obey `prefers-reduced-motion`, automatically disabling transitions when users opt out. Components must respect these token values instead of hard-coding durations.
+
+### Usage guidelines
+
+- Import `src/lib/styles/tokens.css` in global styles (issue #23) before consuming tokens in route-level CSS.
+- When introducing new tokens, prefer descriptive semantic names over raw values (e.g. `--color-alert-danger` vs `--color-red-500`). Update this document and cross-reference any dependent components or utilities.
+- Avoid referencing the raw palette tokens (`--color-light-*`, `--color-dark-*`) outside of the theme management block to keep theme swapping predictable.

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -1,0 +1,204 @@
+:root {
+	color-scheme: light dark;
+
+	/* Color palette source values */
+	--color-light-bg: #f9fafb;
+	--color-light-surface: #ffffff;
+	--color-light-subtle: #f1f5f9;
+	--color-light-text: #111827;
+	--color-light-text-muted: #475569;
+	--color-light-border: #cbd5f5;
+	--color-light-border-strong: #94a3b8;
+	--color-light-accent: #2563eb;
+	--color-light-accent-on: #f8fafc;
+	--color-light-success: #15803d;
+	--color-light-warning: #b45309;
+	--color-light-danger: #b91c1c;
+	--color-light-focus: #1d4ed8;
+	--color-light-muted: #e2e8f0;
+	--color-light-contrast-high: #0f172a;
+
+	--color-dark-bg: #0f172a;
+	--color-dark-surface: #1e293b;
+	--color-dark-subtle: #111c2f;
+	--color-dark-text: #f8fafc;
+	--color-dark-text-muted: #cbd5f5;
+	--color-dark-border: #334155;
+	--color-dark-border-strong: #475569;
+	--color-dark-accent: #60a5fa;
+	--color-dark-accent-on: #0b1120;
+	--color-dark-success: #4ade80;
+	--color-dark-warning: #fbbf24;
+	--color-dark-danger: #f87171;
+	--color-dark-focus: #93c5fd;
+	--color-dark-muted: #1e293b;
+	--color-dark-contrast-high: #f8fafc;
+
+	/* Semantic color tokens */
+	--color-bg: var(--color-light-bg);
+	--color-bg-subtle: var(--color-light-subtle);
+	--color-surface: var(--color-light-surface);
+	--color-surface-muted: var(--color-light-muted);
+	--color-text: var(--color-light-text);
+	--color-text-muted: var(--color-light-text-muted);
+	--color-border: var(--color-light-border);
+	--color-border-strong: var(--color-light-border-strong);
+	--color-contrast-higher: var(--color-light-contrast-high);
+	--color-accent: var(--color-light-accent);
+	--color-accent-on: var(--color-light-accent-on);
+	--color-success: var(--color-light-success);
+	--color-warning: var(--color-light-warning);
+	--color-danger: var(--color-light-danger);
+	--color-focus-ring: var(--color-light-focus);
+
+	/* Typography tokens */
+	--font-family-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+	--font-family-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+	--font-weight-regular: 400;
+	--font-weight-medium: 500;
+	--font-weight-semibold: 600;
+	--font-weight-bold: 700;
+
+	--line-height-tight: 1.1;
+	--line-height-snug: 1.25;
+	--line-height-normal: 1.5;
+	--line-height-relaxed: 1.75;
+
+	--font-size-50: 0.75rem; /* 12px */
+	--font-size-75: 0.875rem; /* 14px */
+	--font-size-100: 1rem; /* 16px */
+	--font-size-200: 1.125rem; /* 18px */
+	--font-size-300: 1.25rem; /* 20px */
+	--font-size-400: 1.5rem; /* 24px */
+	--font-size-500: 1.75rem; /* 28px */
+	--font-size-600: 2rem; /* 32px */
+	--font-size-700: 2.5rem; /* 40px */
+	--font-size-800: 3rem; /* 48px */
+
+	/* Spacing scale (8px grid with 4px fine control) */
+	--space-0: 0rem;
+	--space-1: 0.25rem; /* 4px */
+	--space-2: 0.5rem; /* 8px */
+	--space-3: 0.75rem; /* 12px */
+	--space-4: 1rem; /* 16px */
+	--space-5: 1.5rem; /* 24px */
+	--space-6: 2rem; /* 32px */
+	--space-7: 2.5rem; /* 40px */
+	--space-8: 3rem; /* 48px */
+	--space-9: 4rem; /* 64px */
+	--space-10: 5rem; /* 80px */
+
+	--gap-default: var(--space-4);
+	--section-vertical-padding: var(--space-9);
+
+	/* Border and radius tokens */
+	--border-width-hairline: 0.0625rem; /* 1px */
+	--border-width-thick: 0.125rem; /* 2px */
+	--border-radius-none: 0rem;
+	--border-radius-xs: 0.125rem; /* 2px */
+	--border-radius-sm: 0.25rem; /* 4px */
+	--border-radius-md: 0.5rem; /* 8px */
+	--border-radius-lg: 0.75rem; /* 12px */
+	--border-radius-xl: 1rem; /* 16px */
+	--border-radius-pill: 999rem;
+
+	/* Shadow tokens */
+	--shadow-color: 210deg 22% 13%;
+	--shadow-elevation-1: 0 0.0625rem 0.125rem hsl(var(--shadow-color) / 0.08);
+	--shadow-elevation-2: 0 0.25rem 0.375rem hsl(var(--shadow-color) / 0.12);
+	--shadow-elevation-3: 0 0.5rem 1rem hsl(var(--shadow-color) / 0.18);
+
+	/* Focus tokens */
+	--focus-ring-width: 0.1875rem; /* 3px */
+	--focus-ring-offset: 0.125rem; /* 2px */
+	--focus-ring-style: solid;
+
+	/* Motion tokens */
+	--transition-duration-100: 120ms;
+	--transition-duration-200: 200ms;
+	--transition-duration-300: 320ms;
+	--transition-ease-standard: cubic-bezier(0.2, 0, 0.38, 0.9);
+	--transition-ease-emphasized: cubic-bezier(0.32, 0, 0.67, 0);
+
+	/* Z-index tokens */
+	--z-base: 0;
+	--z-overlay: 10;
+	--z-modal: 100;
+	--z-toast: 1000;
+
+	/* Container tokens */
+	--container-compact: 40rem; /* 640px */
+	--container-content: 64rem; /* 1024px */
+	--container-wide: 80rem; /* 1280px */
+	--container-padding-inline: var(--space-4);
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		color-scheme: dark;
+		--color-bg: var(--color-dark-bg);
+		--color-bg-subtle: var(--color-dark-subtle);
+		--color-surface: var(--color-dark-surface);
+		--color-surface-muted: var(--color-dark-muted);
+		--color-text: var(--color-dark-text);
+		--color-text-muted: var(--color-dark-text-muted);
+		--color-border: var(--color-dark-border);
+		--color-border-strong: var(--color-dark-border-strong);
+		--color-contrast-higher: var(--color-dark-contrast-high);
+		--color-accent: var(--color-dark-accent);
+		--color-accent-on: var(--color-dark-accent-on);
+		--color-success: var(--color-dark-success);
+		--color-warning: var(--color-dark-warning);
+		--color-danger: var(--color-dark-danger);
+		--color-focus-ring: var(--color-dark-focus);
+	}
+}
+
+.theme-dark,
+:root[data-theme='dark'] {
+	color-scheme: dark;
+	--color-bg: var(--color-dark-bg);
+	--color-bg-subtle: var(--color-dark-subtle);
+	--color-surface: var(--color-dark-surface);
+	--color-surface-muted: var(--color-dark-muted);
+	--color-text: var(--color-dark-text);
+	--color-text-muted: var(--color-dark-text-muted);
+	--color-border: var(--color-dark-border);
+	--color-border-strong: var(--color-dark-border-strong);
+	--color-contrast-higher: var(--color-dark-contrast-high);
+	--color-accent: var(--color-dark-accent);
+	--color-accent-on: var(--color-dark-accent-on);
+	--color-success: var(--color-dark-success);
+	--color-warning: var(--color-dark-warning);
+	--color-danger: var(--color-dark-danger);
+	--color-focus-ring: var(--color-dark-focus);
+}
+
+.theme-light,
+:root[data-theme='light'] {
+	color-scheme: light;
+	--color-bg: var(--color-light-bg);
+	--color-bg-subtle: var(--color-light-subtle);
+	--color-surface: var(--color-light-surface);
+	--color-surface-muted: var(--color-light-muted);
+	--color-text: var(--color-light-text);
+	--color-text-muted: var(--color-light-text-muted);
+	--color-border: var(--color-light-border);
+	--color-border-strong: var(--color-light-border-strong);
+	--color-contrast-higher: var(--color-light-contrast-high);
+	--color-accent: var(--color-light-accent);
+	--color-accent-on: var(--color-light-accent-on);
+	--color-success: var(--color-light-success);
+	--color-warning: var(--color-light-warning);
+	--color-danger: var(--color-light-danger);
+	--color-focus-ring: var(--color-light-focus);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	:root {
+		--transition-duration-100: 0ms;
+		--transition-duration-200: 0ms;
+		--transition-duration-300: 0ms;
+	}
+}


### PR DESCRIPTION
## Summary
- add css variable tokens covering color, typography, spacing, radii, shadows, focus, motion, and containers
- provide light/dark palettes with prefers-color-scheme handling and css-only manual overrides
- document token architecture and workflow expectations for the design system milestone

Closes #18.

## Testing
- npm run check
- npm run lint
