### PR TITLE
feat(css): establish base element styles

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -36,3 +36,15 @@ All design tokens live in `src/lib/styles/tokens.css`. The file is organised by 
 - Import `src/lib/styles/tokens.css` in global styles (issue #23) before consuming tokens in route-level CSS.
 - When introducing new tokens, prefer descriptive semantic names over raw values (e.g. `--color-alert-danger` vs `--color-red-500`). Update this document and cross-reference any dependent components or utilities.
 - Avoid referencing the raw palette tokens (`--color-light-*`, `--color-dark-*`) outside of the theme management block to keep theme swapping predictable.
+
+## Base element styles (issue #19)
+
+Baseline rules live in `src/lib/styles/base.css` and focus on structural HTML elements. Key decisions:
+
+- `html` and `body` set typography defaults, background/text colors, and font smoothing using tokens so every route inherits the same reading experience.
+- Headings map to the typographic scale (`--font-size-800` through `--font-size-200`) with snug line heights; paragraphs, lists, blockquotes, and code snippets use spacing tokens to maintain the 8px rhythm.
+- Anchors adopt accent colors with hover and focus treatments driven by the focus ring tokens and `color-mix` to maintain contrast in light and dark modes.
+- Inline code and pre blocks rely on mono fonts, surface-muted backgrounds, and radius tokens; blockquotes gain thicker border accents for readability.
+- A global `:focus-visible` rule ensures consistent outlines, while the reduced-motion media query clamps transitions and scroll behavior for users who opt out of animation.
+
+Import order matters: load `tokens.css` before `base.css` (handled in issue #23) so variable references resolve correctly. Utility classes and components introduced later should extend rather than reset these foundations.

--- a/src/lib/styles/base.css
+++ b/src/lib/styles/base.css
@@ -1,0 +1,188 @@
+html {
+	font-size: 100%;
+	font-family: var(--font-family-sans);
+	line-height: var(--line-height-normal);
+	color: var(--color-text);
+	background-color: var(--color-bg);
+	text-rendering: optimizeLegibility;
+	-webkit-font-smoothing: antialiased;
+}
+
+body {
+	min-height: 100vh;
+	margin: 0;
+	font-weight: var(--font-weight-regular);
+	background-color: var(--color-bg);
+	color: var(--color-text);
+}
+
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+body > * {
+	box-sizing: inherit;
+}
+
+main {
+	display: block;
+}
+
+p,
+ul,
+ol,
+dl,
+blockquote,
+pre,
+figure,
+fieldset {
+	margin: 0 0 var(--space-5);
+}
+
+ul,
+ol {
+	padding-left: var(--space-6);
+	gap: var(--space-2);
+}
+
+li {
+	margin-block: var(--space-1);
+}
+
+hr {
+	border: none;
+	height: var(--border-width-hairline);
+	background-color: var(--color-border);
+	margin-block: var(--space-6);
+}
+
+small {
+	font-size: var(--font-size-75);
+}
+
+code,
+pre {
+	font-family: var(--font-family-mono);
+	font-size: var(--font-size-75);
+	background-color: var(--color-surface-muted);
+	color: var(--color-contrast-higher);
+	border-radius: var(--border-radius-sm);
+}
+
+code {
+	padding: 0 var(--space-1);
+}
+
+pre {
+	padding: var(--space-3);
+	overflow-x: auto;
+}
+
+blockquote {
+	padding: var(--space-3) var(--space-4);
+	border-left: var(--border-width-thick) solid var(--color-border-strong);
+	background-color: var(--color-surface-muted);
+	border-radius: var(--border-radius-md);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	font-weight: var(--font-weight-semibold);
+	line-height: var(--line-height-snug);
+	margin: 0 0 var(--space-3);
+	color: var(--color-text);
+}
+
+h1 {
+	font-size: var(--font-size-800);
+}
+
+h2 {
+	font-size: var(--font-size-600);
+}
+
+h3 {
+	font-size: var(--font-size-500);
+}
+
+h4 {
+	font-size: var(--font-size-400);
+}
+
+h5 {
+	font-size: var(--font-size-300);
+}
+
+h6 {
+	font-size: var(--font-size-200);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+
+a {
+	color: var(--color-accent);
+	text-decoration: underline;
+	text-decoration-thickness: var(--border-width-hairline);
+	text-underline-offset: 0.2em;
+	transition: color var(--transition-duration-200) var(--transition-ease-standard);
+}
+
+a:hover,
+a:focus-visible {
+	color: var(--color-accent-on);
+	background-color: color-mix(in srgb, var(--color-accent) 15%, transparent);
+}
+
+a:visited {
+	color: color-mix(in srgb, var(--color-accent) 70%, var(--color-border-strong));
+}
+
+:focus-visible {
+	outline: var(--focus-ring-width) var(--focus-ring-style) var(--color-focus-ring);
+	outline-offset: var(--focus-ring-offset);
+}
+
+::selection {
+	background-color: color-mix(in srgb, var(--color-accent) 35%, transparent);
+	color: var(--color-accent-on);
+}
+
+img,
+video,
+canvas,
+iframe,
+picture {
+	max-width: 100%;
+	display: block;
+}
+
+svg {
+	display: inline-block;
+	max-width: 100%;
+}
+
+button,
+input,
+select,
+textarea {
+	font: inherit;
+	color: inherit;
+	background-color: inherit;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
+}


### PR DESCRIPTION
## Summary
- add src/lib/styles/base.css to define html/body defaults, typography scale, list rhythm, and text utilities via design tokens
- apply accessible anchor, code, blockquote, and focus-visible styles that respect light/dark themes and reduced motion
- document base element decisions and import order in docs/design-system.md for the design system milestone

Closes #19.

## Testing
- npm run validate:content
- npm run check
- npm run lint
