### PR TITLE
feat(css): add layout primitives

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -48,3 +48,19 @@ Baseline rules live in `src/lib/styles/base.css` and focus on structural HTML el
 - A global `:focus-visible` rule ensures consistent outlines, while the reduced-motion media query clamps transitions and scroll behavior for users who opt out of animation.
 
 Import order matters: load `tokens.css` before `base.css` (handled in issue #23) so variable references resolve correctly. Utility classes and components introduced later should extend rather than reset these foundations.
+
+## Layout primitives (issue #20)
+
+Core layout helpers live in `src/lib/styles/layout.css` and provide predictable spacing without extra tooling:
+
+- `.container` constrains content to the `--container-content` width with responsive inline padding. A `data-width` attribute switches to `compact` or `wide` container tokens as needed.
+- `.section` sets vertical rhythm. Combine with `.section--contained` for in-flow sections or `.section--bleed` to span edge-to-edge while maintaining safe inline padding. Surface variants supply neutral background panels via design tokens.
+- `.stack` arranges children vertically with a configurable gap (default `--space-4`). Use `data-gap="tight"|"loose"` for common variations and `data-align="center"` when aligning content.
+- `.cluster` handles horizontal groups (e.g., pill lists or action bars) with wrapping support. Alignment and spacing rely on custom properties so components can override without new class names.
+- `.grid` creates responsive grids using intrinsic column sizing (`auto-fit` + `minmax`). Data attributes configure gap density, minimum column width, or force fixed column counts on larger breakpoints.
+
+Accessibility guidance:
+
+- Ensure interactive clusters maintain minimum touch targets; adjust `--cluster-gap` if new components require larger hit areas.
+- When using `.section--bleed`, verify focus outlines and skip links remain visible against alternate backgrounds.
+- `.grid[data-columns]` falls back to auto-fit columns below 40rem to avoid forcing cramped layouts.

--- a/src/lib/styles/layout.css
+++ b/src/lib/styles/layout.css
@@ -1,0 +1,134 @@
+:root {
+	--stack-gap: var(--space-4);
+	--cluster-gap: var(--space-3);
+	--grid-gap: var(--space-4);
+	--grid-min-column: 16rem;
+	--section-inline-padding: clamp(var(--space-3), 4vw, var(--space-6));
+}
+
+.container {
+	max-width: var(--container-content);
+	margin-inline: auto;
+	padding-inline: var(--section-inline-padding);
+	width: 100%;
+}
+
+.container[data-width='compact'] {
+	max-width: var(--container-compact);
+}
+
+.container[data-width='wide'] {
+	max-width: var(--container-wide);
+}
+
+.section {
+	padding-block: var(--section-vertical-padding);
+}
+
+.section--contained {
+	max-width: var(--container-content);
+	margin-inline: auto;
+	padding-inline: var(--section-inline-padding);
+}
+
+.section--bleed {
+	width: 100vw;
+	margin-inline: calc(50% - 50vw);
+	padding-inline: var(--section-inline-padding);
+}
+
+.section--surface {
+	background-color: var(--color-surface);
+	color: var(--color-text);
+}
+
+.section--muted {
+	background-color: var(--color-surface-muted);
+	color: var(--color-text);
+}
+
+.stack {
+	display: flex;
+	flex-direction: column;
+	gap: var(--stack-gap);
+}
+
+.stack[data-gap='tight'] {
+	--stack-gap: var(--space-2);
+}
+
+.stack[data-gap='loose'] {
+	--stack-gap: var(--space-6);
+}
+
+.stack[data-align='center'] {
+	align-items: center;
+}
+
+.cluster {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--cluster-gap);
+	align-items: var(--cluster-align, center);
+	justify-content: var(--cluster-justify, flex-start);
+}
+
+.cluster[data-gap='tight'] {
+	--cluster-gap: var(--space-2);
+}
+
+.cluster[data-gap='loose'] {
+	--cluster-gap: var(--space-5);
+}
+
+.cluster[data-justify='between'] {
+	--cluster-justify: space-between;
+}
+
+.cluster[data-justify='center'] {
+	--cluster-justify: center;
+}
+
+.grid {
+	display: grid;
+	gap: var(--grid-gap);
+	grid-template-columns: repeat(auto-fit, minmax(var(--grid-min-column), 1fr));
+}
+
+.grid[data-gap='tight'] {
+	--grid-gap: var(--space-3);
+}
+
+.grid[data-gap='loose'] {
+	--grid-gap: var(--space-6);
+}
+
+.grid[data-min='wide'] {
+	--grid-min-column: 20rem;
+}
+
+.grid[data-min='narrow'] {
+	--grid-min-column: 12rem;
+}
+
+.grid[data-columns='2'] {
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.grid[data-columns='3'] {
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid[data-columns='4'] {
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+@media (max-width: 40rem) {
+	.section--bleed {
+		padding-inline: var(--space-3);
+	}
+
+	.grid[data-columns] {
+		grid-template-columns: repeat(auto-fit, minmax(var(--grid-min-column), 1fr));
+	}
+}


### PR DESCRIPTION
## Summary
- add src/lib/styles/layout.css with container, section, stack, cluster, and grid utilities powered by design tokens
- provide data-attribute variants for gap, alignment, full-bleed sections, and column counts while keeping layouts accessible
- document layout guidance and accessibility considerations in docs/design-system.md for the design system milestone

Closes #20.

## Testing
- npm run validate:content
- npm run check
- npm run lint
