### PR TITLE
feat: integrate global design system styles

### DIFF
--- a/content/projects/21grams/project.json
+++ b/content/projects/21grams/project.json
@@ -4,7 +4,7 @@
 	"aliases": ["21grams-preview"],
 	"title": "21grams",
 	"summary": "Sample project demonstrating the MVP content storage structure.",
-	"status": "draft",
+	"status": "published",
 	"createdAt": "2025-01-01T00:00:00.000Z",
 	"updatedAt": "2025-01-10T00:00:00.000Z",
 	"sortDate": "2025-01-10",

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -117,3 +117,12 @@ Usage notes:
 - Always specify a native `type` attribute on `<button>` elements to avoid unintended form submission.
 - When displaying validation errors, pair `aria-invalid="true"` on the control with an `aria-describedby` reference to a `.form-message` element to announce contextually.
 - Rely on the shared transition tokens; additional component-level animations must respect `prefers-reduced-motion` just as the base implementations do.
+
+## Global integration (issue #23)
+
+The root layout wires the full style stack so tokens and component rules cascade across every route:
+
+- `src/routes/+layout.svelte` imports the CSS files in order: tokens → base → layout → controls → a11y. This guarantees custom properties exist before any utility rules consume them.
+- The skip link in the layout now picks up token-driven colors without inline overrides, and future routes inherit baseline typography, layout helpers, and control styling automatically.
+- When contributing new styles, extend the shared files instead of re-importing them downstream to avoid duplicate bundles. Route-level CSS should be reserved for scoped overrides.
+- Sanity check changes with `npm run lint`, `npm run check`, and a quick local preview to confirm the reduced-motion and focus treatments remain intact.

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
 	import favicon from '$lib/assets/favicon.svg';
+	import '$lib/styles/tokens.css';
+	import '$lib/styles/base.css';
+	import '$lib/styles/layout.css';
+	import '$lib/styles/controls.css';
 	import '$lib/styles/a11y.css';
 
 	let { children } = $props();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 	const { projects } = data;
 </script>
 
-<section>
+<section class="container section">
 	<header>
 		<h1>Selected Work</h1>
 		<p>Recent projects that are ready to share.</p>


### PR DESCRIPTION
Closes #23

## Summary
- load tokens, base, layout, controls, and a11y styles from the root layout so every route inherits the system
- document the integration order and contributor guidance in docs/design-system.md

## Testing
- npm run validate:content
- npm run check
- npm run lint