### PR TITLE
fix(deploy): prerender portfolio homepage

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,6 +1,8 @@
 import type { PageServerLoad } from './$types';
 import { loadPublishedProjects } from '$lib/server/projects';
 
+export const prerender = true;
+
 export const load: PageServerLoad = async () => {
 	const projects = await loadPublishedProjects();
 


### PR DESCRIPTION
## Summary

- prerender the portfolio homepage during the build
- serve repository-backed project content as static output instead of reading it from a serverless filesystem at request time

## Root cause

The homepage server load reads `content/projects` with `fs.readdir(process.cwd())`. Vercel validates those files during the build, but the dynamic filesystem path is not traced into the deployed serverless function. The function therefore throws before rendering the homepage and returns a SvelteKit 500 error.

## Impact

The homepage is generated while repository content is available and served as static HTML. This removes the failing runtime filesystem dependency and is appropriate because portfolio content changes only when the repository is redeployed.

## Validation

- `npm run lint`
- `npm run check`
- `npm run build` with Node 24
- confirmed `.svelte-kit/output/prerendered/pages/index.html` and `__data.json` are generated
