### PR TITLE
feat(portfolio): clarify screenshots and expand project navigation

### DIFF
--- a/src/lib/components/ProjectScreenshot.svelte
+++ b/src/lib/components/ProjectScreenshot.svelte
@@ -14,8 +14,37 @@
 	let {
 		slug,
 		image,
-		compact = false
-	}: { slug: string; image?: ProjectImage; compact?: boolean } = $props();
+		compact = false,
+		frame: frameOverride,
+		frameLabel: frameLabelOverride,
+		cursorLabel
+	}: {
+		slug: string;
+		image?: ProjectImage;
+		compact?: boolean;
+		frame?: 'plain' | 'phone' | 'browser';
+		frameLabel?: string;
+		cursorLabel?: string;
+	} = $props();
+
+	let cursorLabelVisible = $state(false);
+	let cursorLabelX = $state(0);
+	let cursorLabelY = $state(0);
+
+	function positionCursorLabel(event: PointerEvent) {
+		if (!cursorLabel || event.pointerType === 'touch') return;
+
+		const visual = event.currentTarget as HTMLElement;
+		const bounds = visual.getBoundingClientRect();
+		const pointerX = event.clientX - bounds.left;
+		const pointerY = event.clientY - bounds.top;
+		const placeLeft = pointerX > bounds.width - 10 * 16;
+		const placeAbove = pointerY > bounds.height - 3.5 * 16;
+
+		cursorLabelX = pointerX + (placeLeft ? -7.25 * 16 : 1 * 16);
+		cursorLabelY = pointerY + (placeAbove ? -2.5 * 16 : 1 * 16);
+		cursorLabelVisible = true;
+	}
 
 	const usesCompactSource = $derived(Boolean(compact && image?.compactUrl));
 	const versionedSource = $derived(
@@ -35,9 +64,12 @@
 		usesCompactSource ? (image?.compactAlt ?? image?.alt ?? '') : (image?.alt ?? '')
 	);
 	const frame = $derived(
-		compact ? (image?.compactFrame ?? image?.frame ?? 'plain') : (image?.frame ?? 'plain')
+		frameOverride ??
+			(compact ? (image?.compactFrame ?? image?.frame ?? 'plain') : (image?.frame ?? 'plain'))
 	);
-	const frameLabel = $derived(image?.compactFrameLabel ?? slug.replaceAll('-', ' '));
+	const frameLabel = $derived(
+		frameLabelOverride ?? image?.compactFrameLabel ?? slug.replaceAll('-', ' ')
+	);
 	const frameBackground = $derived(
 		versionedSource ? `--frame-image: url("${versionedSource}")` : undefined
 	);
@@ -55,7 +87,15 @@
 	</picture>
 {/snippet}
 
-<div class:compact class="visual" data-project={slug} data-frame={frame} style={frameBackground}>
+<div
+	class:compact
+	class="visual"
+	data-project={slug}
+	data-frame={frame}
+	style={frameBackground}
+	onpointermove={positionCursorLabel}
+	onpointerleave={() => (cursorLabelVisible = false)}
+>
 	{#if image && versionedSource}
 		{#if frame === 'phone'}
 			<div class="device device--phone">
@@ -77,6 +117,14 @@
 		{/if}
 	{:else}
 		<div class="fallback" aria-hidden="true">{slug.replaceAll('-', ' ')}</div>
+	{/if}
+	{#if cursorLabel}
+		<span
+			class:visible={cursorLabelVisible}
+			class="cursor-label"
+			style={`--cursor-label-x: ${cursorLabelX}px; --cursor-label-y: ${cursorLabelY}px;`}
+			aria-hidden="true">{cursorLabel}</span
+		>
 	{/if}
 </div>
 
@@ -206,6 +254,23 @@
 			var(--color-surface-muted);
 	}
 
+	.visual:not(.compact)[data-frame='browser'] {
+		aspect-ratio: auto;
+		overflow: visible;
+		padding: clamp(1.25rem, 3vw, 2rem);
+		background: transparent;
+		cursor: default;
+	}
+
+	.visual:not(.compact)[data-frame='browser'] .device--browser {
+		width: 100%;
+		height: auto;
+	}
+
+	.visual:not(.compact)[data-frame='browser'] .device__screen {
+		aspect-ratio: 16 / 9;
+	}
+
 	.device--browser {
 		display: grid;
 		grid-template-rows: auto minmax(0, 1fr);
@@ -279,6 +344,31 @@
 		object-fit: cover;
 		object-position: center top;
 		transition: transform 500ms var(--transition-ease-standard);
+	}
+
+	.cursor-label {
+		position: absolute;
+		top: 0;
+		left: 0;
+		z-index: 2;
+		padding: 0.35rem 0.5rem;
+		border: 1px solid var(--color-border-strong);
+		background: var(--color-text);
+		box-shadow: var(--shadow-elevation-2);
+		color: var(--color-bg);
+		font-family: var(--font-family-mono);
+		font-size: 0.6875rem;
+		letter-spacing: var(--letter-spacing-label);
+		line-height: 1;
+		opacity: 0;
+		pointer-events: none;
+		text-transform: uppercase;
+		transform: translate(var(--cursor-label-x), var(--cursor-label-y));
+		white-space: nowrap;
+	}
+
+	.cursor-label.visible {
+		opacity: 1;
 	}
 
 	:global(.project-card:hover) .visual img,
@@ -377,6 +467,16 @@
 	@media (prefers-reduced-motion: reduce) {
 		.visual img {
 			transition: none;
+		}
+
+		.cursor-label {
+			display: none;
+		}
+	}
+
+	@media (hover: none), (pointer: coarse) {
+		.cursor-label {
+			display: none;
 		}
 	}
 

--- a/src/routes/projects/[slug]/+page.server.ts
+++ b/src/routes/projects/[slug]/+page.server.ts
@@ -35,8 +35,15 @@ export const load: PageServerLoad = async ({ params }) => {
 		error(404, 'Project not found');
 	}
 
+	const project = projects[projectIndex];
+	const nextProject = projects[(projectIndex + 1) % projects.length];
+	const moreProjects = projects
+		.filter(({ slug }) => slug !== project.slug && slug !== nextProject.slug)
+		.slice(0, 8);
+
 	return {
-		project: projects[projectIndex],
-		nextProject: projects[(projectIndex + 1) % projects.length]
+		project,
+		nextProject,
+		moreProjects
 	};
 };

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -49,12 +49,23 @@
 		return sections;
 	}
 
+	function displayHost(url?: string): string | undefined {
+		if (!url) return undefined;
+
+		try {
+			return new URL(url).hostname.replace(/^www\./, '');
+		} catch {
+			return undefined;
+		}
+	}
+
 	const sections = $derived(parseSections(data.project.body ?? ''));
 	const homeUrl = absoluteUrl('/');
 	const canonicalUrl = $derived(
 		data.project.canonical ?? absoluteUrl(`/projects/${data.project.slug}`)
 	);
 	const pageTitle = $derived(`${data.project.title} — ${SITE.name}`);
+	const liveSiteHost = $derived(displayHost(data.project.liveUrl));
 	const structuredData = $derived({
 		'@context': 'https://schema.org',
 		'@graph': [
@@ -172,9 +183,31 @@
 		</dl>
 	</header>
 
-	<div class="visual-wrap">
-		<ProjectScreenshot slug={data.project.slug} image={data.project.heroImage} />
-	</div>
+	<figure class="visual-wrap">
+		<figcaption class="visual-rail">
+			<div class="visual-caption">
+				<span>Product screenshot</span>
+				<span>Static preview</span>
+			</div>
+			{#if data.project.liveUrl}
+				<a
+					href={data.project.liveUrl}
+					rel="noopener noreferrer"
+					target="_blank"
+					aria-label={`Open the ${data.project.title} live site (opens in a new tab)`}
+				>
+					Open live site <span aria-hidden="true">↗</span>
+				</a>
+			{/if}
+		</figcaption>
+		<ProjectScreenshot
+			slug={data.project.slug}
+			image={data.project.heroImage}
+			frame="browser"
+			frameLabel={liveSiteHost ?? data.project.title}
+			cursorLabel="Static preview"
+		/>
+	</figure>
 
 	<div class="case-study">
 		{#each sections as section, index}
@@ -360,7 +393,55 @@
 	}
 
 	.visual-wrap {
-		width: min(100%, 110rem);
+		width: min(calc(100% - clamp(2rem, 8vw, 8rem)), 72rem);
+		margin-bottom: 0;
+	}
+
+	.visual-rail {
+		display: flex;
+		min-height: var(--target-size-min);
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		border-top: var(--border-width-structure) solid var(--color-border);
+		font-family: var(--font-family-mono);
+		font-size: var(--font-size-label);
+		letter-spacing: var(--letter-spacing-label);
+		text-transform: uppercase;
+	}
+
+	.visual-caption {
+		display: flex;
+		align-items: center;
+		gap: 0.65rem;
+	}
+
+	.visual-caption span:first-child {
+		color: var(--color-accent);
+	}
+
+	.visual-caption span:last-child {
+		color: var(--color-text-muted);
+	}
+
+	.visual-caption span:last-child::before {
+		content: '·';
+		margin-right: 0.65rem;
+	}
+
+	.visual-rail a {
+		display: inline-flex;
+		min-height: var(--target-size-min);
+		align-items: center;
+		gap: 0.4rem;
+		color: var(--color-text);
+		text-decoration: none;
+	}
+
+	.visual-rail a:hover,
+	.visual-rail a:focus-visible {
+		color: var(--color-accent);
+		background: transparent;
 	}
 
 	.case-study {
@@ -503,6 +584,23 @@
 
 		.project-action {
 			min-height: 7.5rem;
+		}
+
+		.visual-rail {
+			align-items: flex-start;
+			padding-block: 0.55rem;
+		}
+
+		.visual-caption {
+			min-height: var(--target-size-min);
+			flex-direction: column;
+			align-items: flex-start;
+			justify-content: center;
+			gap: 0.1rem;
+		}
+
+		.visual-caption span:last-child::before {
+			display: none;
 		}
 	}
 

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -239,13 +239,35 @@
 		<strong>{data.nextProject.title}</strong>
 		<i aria-hidden="true">↗</i>
 	</a>
+
+	{#if data.moreProjects.length > 0}
+		<section class="more-projects" aria-labelledby="more-projects-title">
+			<header>
+				<h2 id="more-projects-title">More selected work</h2>
+				<p>Elsewhere in the portfolio</p>
+			</header>
+			<div class="more-projects__grid" data-count={Math.min(data.moreProjects.length, 4)}>
+				{#each data.moreProjects as project}
+					<a class="more-project" href={`/projects/${project.slug}`}>
+						<span class="more-project__category">{project.category}</span>
+						<strong>{project.title}</strong>
+						<span class="more-project__footer">
+							<span>{project.timeframe?.label ?? project.sortDate}</span>
+							<i aria-hidden="true">↗</i>
+						</span>
+					</a>
+				{/each}
+			</div>
+		</section>
+	{/if}
 </article>
 
 <style>
 	.project-hero,
 	.visual-wrap,
 	.case-study,
-	.next-project {
+	.next-project,
+	.more-projects {
 		width: min(100% - 2rem, 94rem);
 		margin-inline: auto;
 	}
@@ -540,6 +562,136 @@
 		transform: translate(0.3rem, -0.3rem);
 	}
 
+	.more-projects {
+		padding-bottom: clamp(4rem, 8vw, 7rem);
+	}
+
+	.more-projects > header {
+		display: flex;
+		min-height: var(--target-size-min);
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		border-top: var(--border-width-structure) solid var(--color-border);
+		font-family: var(--font-family-mono);
+		font-size: var(--font-size-label);
+		letter-spacing: var(--letter-spacing-label);
+		text-transform: uppercase;
+	}
+
+	.more-projects h2,
+	.more-projects > header p {
+		margin: 0;
+		font: inherit;
+		letter-spacing: inherit;
+		text-transform: inherit;
+	}
+
+	.more-projects h2 {
+		color: var(--color-accent);
+	}
+
+	.more-projects > header p,
+	.more-project__category,
+	.more-project__footer {
+		color: var(--color-text-muted);
+	}
+
+	.more-projects__grid {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		gap: 1px;
+		border-block: 1px solid var(--color-border);
+		background: var(--color-border);
+	}
+
+	.more-projects__grid[data-count='1'] {
+		grid-template-columns: minmax(0, 32rem);
+	}
+
+	.more-projects__grid[data-count='2'] {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.more-projects__grid[data-count='3'] {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.more-project {
+		display: flex;
+		min-height: clamp(10rem, 14vw, 13rem);
+		flex-direction: column;
+		padding: clamp(1rem, 2vw, 1.4rem);
+		background: var(--color-bg);
+		color: var(--color-text);
+		text-decoration: none;
+		transition:
+			background-color 160ms ease,
+			color 160ms ease;
+	}
+
+	.more-project__category,
+	.more-project__footer {
+		font-family: var(--font-family-mono);
+		font-size: var(--font-size-label);
+		letter-spacing: var(--letter-spacing-label);
+		text-transform: uppercase;
+	}
+
+	.more-project strong {
+		margin-top: auto;
+		font-size: clamp(1.5rem, 2.4vw, 2.5rem);
+		line-height: 0.98;
+		letter-spacing: -0.045em;
+	}
+
+	.more-project__footer {
+		display: flex;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-top: 1.5rem;
+	}
+
+	.more-project__footer i {
+		color: var(--color-text);
+		font-size: 1.25rem;
+		font-style: normal;
+		line-height: 1;
+		transition: transform 160ms ease;
+	}
+
+	.more-project:hover,
+	.more-project:focus-visible {
+		background: var(--color-text);
+		color: var(--color-bg);
+	}
+
+	.more-project:hover .more-project__category,
+	.more-project:hover .more-project__footer,
+	.more-project:hover .more-project__footer i,
+	.more-project:focus-visible .more-project__category,
+	.more-project:focus-visible .more-project__footer,
+	.more-project:focus-visible .more-project__footer i {
+		color: var(--color-bg);
+	}
+
+	.more-project:hover .more-project__footer i,
+	.more-project:focus-visible .more-project__footer i {
+		transform: translate(0.2rem, -0.2rem);
+	}
+
+	@media (max-width: 64rem) {
+		.more-projects__grid,
+		.more-projects__grid[data-count='3'] {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		.more-projects__grid[data-count='1'] {
+			grid-template-columns: minmax(0, 32rem);
+		}
+	}
+
 	@media (max-width: 48rem) {
 		.project-actions {
 			grid-template-columns: 1fr;
@@ -566,7 +718,8 @@
 		.project-hero,
 		.visual-wrap,
 		.case-study,
-		.next-project {
+		.next-project,
+		.more-projects {
 			width: min(100% - 1.25rem, 94rem);
 		}
 
@@ -602,6 +755,21 @@
 		.visual-caption span:last-child::before {
 			display: none;
 		}
+
+		.more-projects > header {
+			align-items: flex-start;
+			padding-block: 0.8rem;
+		}
+
+		.more-projects > header p {
+			max-width: 11rem;
+			text-align: right;
+		}
+
+		.more-projects__grid,
+		.more-projects__grid[data-count] {
+			grid-template-columns: 1fr;
+		}
 	}
 
 	@media (prefers-reduced-motion: reduce) {
@@ -613,6 +781,11 @@
 		.project-action:hover,
 		.project-action:focus-visible {
 			transform: none;
+		}
+
+		.more-project,
+		.more-project__footer i {
+			transition-duration: 0ms;
 		}
 	}
 </style>


### PR DESCRIPTION
## What changed

- presents case-study hero imagery explicitly as framed, static product screenshots
- adds a direct live-site action alongside each screenshot where available
- adds responsive “More selected work” navigation after the next-project feature
- enriches screenshot framing with clearer browser labels and a desktop pointer cue

## Why

These updates make the relationship between portfolio screenshots and hosted products clearer while giving visitors more useful paths through the work.

## Validation

- `npm run lint`
- `npm run check` — 0 errors and 0 warnings
- `npm run build` under Node 22.12.0
- content validation — 6 projects (5 published, 1 draft)
- Vercel preview deployment completed successfully